### PR TITLE
coverage testing with istanbul

### DIFF
--- a/lib/experiment.js
+++ b/lib/experiment.js
@@ -70,39 +70,6 @@ class Experiment {
 
     return results;
   }
-
-  sample() {
-    // hardcoded test
-
-    // we have a uuid
-    if (typeof this.manager.uuid !== undefined) {
-      // lang is eng
-      if (this.manager.lang === 'eng') {
-        // manager is in first half of buckets
-        if (this.manager.isInBucket(0, 50)) {
-          return this.manager.activeExperiment({
-            'message': 'hello world',
-            'messageTitle': 'in bucket 50 or lesser'
-          });
-          // manager is in second half of buckets
-        } else {
-          return this.manager.activeExperiment({
-            'message': 'hello world',
-            'messageTitle': 'in bucket 50 or greater'
-          });
-        }
-        // lang is not eng
-      } else {
-        return this.manager.activeExperiment({
-          'message': 'hola mundo (non-eng)',
-          'messageTitle': 'zip zap zoop'
-        });
-      }
-      // no uuid
-    } else {
-      return this.manager.inactiveExperimentReturnArray();
-    }
-  }
 }
 
 module.exports = Experiment;

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "supertest": "^1.1.0"
   },
   "scripts": {
-    "test": "CONFIG_FILE=test/test_config.json mocha --compilers js:babel-core/register test/*.js",
-    "cover": "CONFIG_FILE=test/test_config.json ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --compilers js:babel-core/register test/*.js",
+    "test": "CONFIG_FILE=test/test_config.json ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --compilers js:babel-core/register test/*.js",
     "start": "CONFIG_FILE=config/example_config.json node index.js"
   },
   "author": "Miles Crabill",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
     "babel-preset-es2015": "^6.6.0",
     "mocha": "^2.3.2",
     "should": "^8.3.0",
+    "istanbul": "^1.0.0-alpha.2",
     "supertest": "^1.1.0"
   },
   "scripts": {
     "test": "CONFIG_FILE=test/test_config.json mocha --compilers js:babel-core/register test/*.js",
+    "cover": "CONFIG_FILE=test/test_config.json ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --compilers js:babel-core/register test/*.js",
     "start": "CONFIG_FILE=config/example_config.json node index.js"
   },
   "author": "Miles Crabill",


### PR DESCRIPTION
add istanbul 1.0.x (alpha for es6 + babel reasons) for coverage, add npm run cover command to get test coverage information

current coverage:
Statements   : 82.88% ( 92/111 )
Branches     : 71.21% ( 47/66 )
Functions    : 75% ( 9/12 )
Lines        : 82.08% ( 87/106 )
