### PR TITLE
remove dev config from experiments directory

### DIFF
--- a/experiments/dev.json
+++ b/experiments/dev.json
@@ -1,9 +1,0 @@
-{
-  "ip": "127.0.0.1",
-  "port": "8080",
-  "baseUrl": "/",
-  "mainServerUrl": "https://switchboard-server.dev.mozaws.net",
-  "urlsUrl": "urls",
-  "numBuckets": 100,
-  "experimentsFile": "config/experiments.json"
-}


### PR DESCRIPTION
that configuration was never intended to be in that location, or really in the repository at all
nothing sensitive though, just the url of the old dev test server which now redirects to prod
